### PR TITLE
Add nginx.conf and CORS header

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,2 +1,3 @@
 FROM nginx
 COPY ./dist/ /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,9 +8,6 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-    }
-    
-    location /links.json {
         add_header 'Access-Control-Allow-Origin' '*';
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+    
+    location /links.json {
+        add_header 'Access-Control-Allow-Origin' '*';
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
This PR adds CORS headers to allow an external website (like MyECL) to get Centralisation links.

[x] Add nginx configuration to the container
[x] Add CORS headers